### PR TITLE
Affix dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "start": "bash ./script/server.sh"
   },
   "dependencies": {
-    "cheerio": "",
-    "color-logger": ""
+    "cheerio": "0.20.0",
+    "color-logger": "0.0.3"
   },
   "devDependencies": {
     "babel": "",


### PR DESCRIPTION
color-logger introduced a regression for older versions of node with the latest releases.

This PR aims to affix the versions and allows the package author to upgrade to the newest version of color-logger (and other dependencies) without implicitly breaking builds.

Right now, ESDoc breaks in 0.12 and 0.10, which are (sadly) still supported.
